### PR TITLE
Potential fix for code scanning alert no. 17: Database query built from user-controlled sources

### DIFF
--- a/backend/src/controllers/todoController.js
+++ b/backend/src/controllers/todoController.js
@@ -152,7 +152,7 @@ async function undoDelete(req, res) {
   const { taskID, userId } = req.body;
 
   const deleteStatus = await Todo.findOneAndUpdate(
-    { _id: taskID, userId: userId },
+    { _id: taskID, userId: { $eq: userId } },
     { $set: { deleted: false } }
   );
 
@@ -177,7 +177,7 @@ async function deleteDeletedTask(req, res) {
   const { userId } = req.body;
 
   try {
-    const noOfTaskToDelete = await Todo.find({ userId: userId, deleted: true });
+    const noOfTaskToDelete = await Todo.find({ userId: { $eq: userId }, deleted: true });
 
     if (noOfTaskToDelete.length === 0) {
       return res.send({
@@ -186,7 +186,7 @@ async function deleteDeletedTask(req, res) {
       });
     } else {
       const finalDeleteStatus = await Todo.deleteMany({
-        userId: userId,
+        userId: { $eq: userId },
         deleted: true,
       });
 


### PR DESCRIPTION
Potential fix for [https://github.com/dev-kant-kumar/To-Do/security/code-scanning/17](https://github.com/dev-kant-kumar/To-Do/security/code-scanning/17)

To fix the problem, we need to ensure that the `userId` is treated as a literal value and not as a query object. This can be achieved by using the `$eq` operator in MongoDB queries. This will ensure that the `userId` is interpreted as a literal value and not as a query object, preventing NoSQL injection attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
